### PR TITLE
Add linter tests to manda_coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,5 +106,10 @@ install(TARGETS ${PROJECT_NAME}_action_server
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,9 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
   <depend>visualization_msgs</depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Summary

- Add `ament_lint_auto` and `ament_lint_common` test dependencies to `package.xml`
- Add `BUILD_TESTING` block with `ament_lint_auto_find_test_dependencies()` to `CMakeLists.txt`

## Test plan

- [x] Package builds successfully
- [x] `colcon test` runs linter tests (copyright, cpplint, uncrustify, lint_cmake, flake8)
- [ ] Pre-existing lint findings to be addressed in follow-up issues

Closes #2

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
