### PR TITLE
Expose coverage-density tuning constants as declared parameters (#4)

### DIFF
--- a/.agent/work-plans/issue-4/plan.md
+++ b/.agent/work-plans/issue-4/plan.md
@@ -38,10 +38,17 @@ Current state (verified against source):
 
    | ROS name | default | range |
    |---|---|---|
-   | `swath_overlap` | `0.2` | `[0.0, 1.0]`, step `0.0` |
-   | `max_bend_angle` | `60.0` | `[0.0, 90.0]`, step `0.0` |
-   | `swath_record_interval` | `10.0` | `(0.0, ∞)` — use `from_value=0.001` |
-   | `min_allowable_swath` | `0.0` | `[0.0, ∞)` — use `to_value=0.0` to omit upper bound |
+   | `swath_overlap` | `0.2` | `from_value=0.0`, `to_value=1.0`, step `0.0` |
+   | `max_bend_angle` | `60.0` | `from_value=0.0`, `to_value=90.0`, step `0.0` |
+   | `swath_record_interval` | `10.0` | `from_value=0.001`, `to_value=std::numeric_limits<double>::max()` |
+   | `min_allowable_swath` | `0.0` | `from_value=0.0`, `to_value=std::numeric_limits<double>::max()` |
+
+   Unbounded-above params use `std::numeric_limits<double>::max()` as a finite
+   upper sentinel (requires `#include <limits>`). Do **not** use `to_value=0.0`
+   to mean "no upper bound" — that yields a degenerate/zero-width range that
+   rejects the default at `configure()` time. Declarations are factored through
+   a local `declare_bounded` lambda that builds the descriptor, declares the
+   parameter (guarded by `has_parameter`), and returns the read-back value.
 
 3. **Read parameters and apply** — after `declare_parameter`, `get_parameter`
    each value, store in the existing `m_swath_overlap` / `m_max_bend_angle`
@@ -53,19 +60,29 @@ Current state (verified against source):
    (let `RecordSwath` use its default of `10`; `configure()` will override it).
 
 5. **Add unit tests** in `test/test_parameters.cpp` using
-   `ament_add_ros_isolated_gtest`. Two tests:
-   - `TestDefaultParameters` — create node, build `SurveyPath`, call `configure()`,
-     verify each parameter is set to its default value via `get_parameter`.
-   - `TestOutOfRangeRejection` — after `configure()`, call `node->set_parameter()`
-     with values outside each declared range; verify each returns
-     `result.successful == false`.
+   `ament_add_ros_isolated_gtest`. The fixture inits/shuts down rclcpp per test
+   (no custom `main()`, so no clash with the gtest main ament links). Tests:
+   - `SurveyPathParameterTest.DefaultParameters` — create node, build `SurveyPath`,
+     call `configure()`, verify each parameter is set to its default via
+     `get_parameter`.
+   - `SurveyPathParameterTest.OutOfRangeRejection` — after `configure()`, call
+     `node->set_parameter()` with values outside each declared range; verify each
+     returns `result.successful == false`.
+   - `SurveyPathParameterTest.InRangeAccepted` — symmetric check that valid values
+     are accepted.
+   - `RecordSwathThreshold.{Above,Below,Default}Threshold*` — exercise
+     `RecordSwath::SwathWidth()` thresholding directly: a recorded width below
+     `min_allowable_swath` returns `0.0` (drives PathPlan's `all_zero`
+     coverage-complete check), at/above returns the real width, and the default
+     `0.0` threshold never zeroes a positive width.
 
 6. **Update `CMakeLists.txt`** — inside `BUILD_TESTING` block, add
-   `ament_add_ros_isolated_gtest`, link against the `manda_coverage` library and
-   `rclcpp`.
+   `find_package(ament_cmake_ros REQUIRED)` (to expose
+   `ament_add_ros_isolated_gtest`), declare the `test_parameters` test, and link
+   it against the `manda_coverage` library and `rclcpp`.
 
-7. **Update `package.xml`** — add `<test_depend>ament_cmake_ros</test_depend>` if
-   `ament_add_ros_isolated_gtest` is not already available.
+7. **`package.xml`** — no change needed: `ament_cmake_ros` is already a
+   `buildtool_depend`, so no `<test_depend>` add is required.
 
 ## Files to Change
 
@@ -75,9 +92,9 @@ Current state (verified against source):
 | `src/RecordSwath.cpp` | Implement setters; threshold `m_min_allowable_swath` in `SwathWidth()` |
 | `include/manda_coverage/SurveyPath.h` | Delete `m_swath_interval`; no new members needed |
 | `src/SurveyPath.cpp` | Declare 4 params with descriptors in `configure()`; remove `(10)` from constructor initializer |
-| `CMakeLists.txt` | Add test target in `BUILD_TESTING` block |
-| `package.xml` | Add `ament_cmake_ros` test depend if missing |
-| `test/test_parameters.cpp` | New: parameter default + out-of-range tests |
+| `CMakeLists.txt` | Add `find_package(ament_cmake_ros)` + `test_parameters` target in `BUILD_TESTING` block |
+| `package.xml` | No change — `ament_cmake_ros` already a `buildtool_depend` |
+| `test/test_parameters.cpp` | New: parameter default/range tests + `SwathWidth()` thresholding tests |
 
 ## Principles Self-Check
 

--- a/.agent/work-plans/issue-4/plan.md
+++ b/.agent/work-plans/issue-4/plan.md
@@ -28,7 +28,12 @@ Current state (verified against source):
    `SetMinAllowableSwath(double)` — so `SurveyPath::configure()` can push
    parameter values after construction. Wire `m_min_allowable_swath` into
    `SwathWidth()`: return `0.0` when width is below the threshold (PathPlan's
-   `all_zero` check then naturally signals coverage-complete).
+   `all_zero` check then naturally signals coverage-complete). The threshold is
+   scoped to `SwathWidth()` only in Phase 1 — the sibling accessors
+   `SwathOuterPts()`/`OuterPoint()`/`AllSwathWidths()` are intentionally left
+   un-thresholded (the default threshold of `0.0` is no behavior change today;
+   consistent below-threshold handling across the siblings is deferred to a
+   later phase).
 
 2. **Declare parameters in `SurveyPath::configure()`** — follow the existing
    `has_parameter` + `declare_parameter` pattern. Add a

--- a/.agent/work-plans/issue-4/plan.md
+++ b/.agent/work-plans/issue-4/plan.md
@@ -1,0 +1,113 @@
+# Plan: Expose coverage-density tuning constants as declared parameters
+
+## Issue
+
+https://github.com/rolker/manda_coverage/issues/4
+
+## Context
+
+Four constants controlling coverage density are hardcoded in `SurveyPath` /
+`RecordSwath` and cannot be changed without a code rebuild. The issue promotes
+them to ROS 2 declared parameters with `ParameterDescriptor` bounds so they
+are settable at launch time. Phase 1 only — live/runtime settability is Phase 2.
+
+Current state (verified against source):
+
+- `m_swath_overlap = 0.2` (`SurveyPath.h:73`) — passed to `PathPlan` as `margin`
+- `m_max_bend_angle = 60` (`SurveyPath.h:74`) — passed to `PathPlan`
+- Swath record interval hardcoded `(10)` in `SurveyPath.cpp:32` constructor initializer
+- `m_min_allowable_swath = 0` (`RecordSwath.cpp:23`) — initialized but **never read**;
+  needs to be wired into `SwathWidth()` so the PathPlan `all_zero` check respects it
+- `m_swath_interval = 10` (`SurveyPath.h:71`) — dead member, never read, delete it
+
+`PathPlan` is only instantiated from `SurveyPath.cpp` — no external callers.
+
+## Approach
+
+1. **Add setters to `RecordSwath`** — `SetInterval(double)` and
+   `SetMinAllowableSwath(double)` — so `SurveyPath::configure()` can push
+   parameter values after construction. Wire `m_min_allowable_swath` into
+   `SwathWidth()`: return `0.0` when width is below the threshold (PathPlan's
+   `all_zero` check then naturally signals coverage-complete).
+
+2. **Declare parameters in `SurveyPath::configure()`** — follow the existing
+   `has_parameter` + `declare_parameter` pattern. Add a
+   `rcl_interfaces::msg::ParameterDescriptor` with `floating_point_range`
+   (min/max/step) and `description`/`additional_constraints` for units.
+   Parameters:
+
+   | ROS name | default | range |
+   |---|---|---|
+   | `swath_overlap` | `0.2` | `[0.0, 1.0]`, step `0.0` |
+   | `max_bend_angle` | `60.0` | `[0.0, 90.0]`, step `0.0` |
+   | `swath_record_interval` | `10.0` | `(0.0, ∞)` — use `from_value=0.001` |
+   | `min_allowable_swath` | `0.0` | `[0.0, ∞)` — use `to_value=0.0` to omit upper bound |
+
+3. **Read parameters and apply** — after `declare_parameter`, `get_parameter`
+   each value, store in the existing `m_swath_overlap` / `m_max_bend_angle`
+   members. Call `m_swath_record.SetInterval()` and
+   `m_swath_record.SetMinAllowableSwath()`.
+
+4. **Remove dead member** — delete `m_swath_interval = 10` from `SurveyPath.h`
+   and remove the `m_swath_record(10)` from the constructor initializer list
+   (let `RecordSwath` use its default of `10`; `configure()` will override it).
+
+5. **Add unit tests** in `test/test_parameters.cpp` using
+   `ament_add_ros_isolated_gtest`. Two tests:
+   - `TestDefaultParameters` — create node, build `SurveyPath`, call `configure()`,
+     verify each parameter is set to its default value via `get_parameter`.
+   - `TestOutOfRangeRejection` — after `configure()`, call `node->set_parameter()`
+     with values outside each declared range; verify each returns
+     `result.successful == false`.
+
+6. **Update `CMakeLists.txt`** — inside `BUILD_TESTING` block, add
+   `ament_add_ros_isolated_gtest`, link against the `manda_coverage` library and
+   `rclcpp`.
+
+7. **Update `package.xml`** — add `<test_depend>ament_cmake_ros</test_depend>` if
+   `ament_add_ros_isolated_gtest` is not already available.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `include/manda_coverage/RecordSwath.h` | Add `SetInterval()`, `SetMinAllowableSwath()` public methods |
+| `src/RecordSwath.cpp` | Implement setters; threshold `m_min_allowable_swath` in `SwathWidth()` |
+| `include/manda_coverage/SurveyPath.h` | Delete `m_swath_interval`; no new members needed |
+| `src/SurveyPath.cpp` | Declare 4 params with descriptors in `configure()`; remove `(10)` from constructor initializer |
+| `CMakeLists.txt` | Add test target in `BUILD_TESTING` block |
+| `package.xml` | Add `ament_cmake_ros` test depend if missing |
+| `test/test_parameters.cpp` | New: parameter default + out-of-range tests |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Promotes hardcoded knobs to operator-visible parameters with descriptor bounds |
+| A change includes its consequences | Tests cover defaults and range enforcement; dead member retired |
+| Only what's needed | Phase 1 scope only — no runtime settability, no extra abstraction |
+| Test what breaks | Tests exercise the ROS 2 parameter declaration behavior, not just metadata |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 — Worktree isolation | Yes | Working on `feature/issue-4` branch |
+| ADR-0008 — Follow ROS 2 conventions | Yes | `ParameterDescriptor` with `floating_point_range` in `configure()` is the correct ROS 2 pattern |
+| ADR-0013 — progress.md vocabulary | Yes | Plan Authored entry follows |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `RecordSwath` — add setters | `SurveyPath::configure()` calls them | Yes |
+| `SwathWidth()` thresholds | Coverage-complete behavior changes when `min_allowable_swath > 0` | Yes — this is the intent |
+| `PathPlan` constructor callers | None outside package | Verified — no action |
+
+## Open Questions
+
+- None — scope is fully defined by the issue; all file paths verified against source.
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -171,7 +171,7 @@ Ready for review-code. No push/PR performed (host publishes after local review).
 
 ### Findings
 - [x] (suggestion) `min_allowable_swath` threshold applied in `SwathWidth()` but not `SwathOuterPts`/`OuterPoint`/`AllSwathWidths` — partial below-threshold coverage keeps `all_zero` false and zero-offsets sub-threshold points; document or apply consistently + add PathPlan integration test (cross-pass confirmed: Lens A + Lens B) — `src/RecordSwath.cpp:217` / `src/PathPlan.cpp:85` (documented per operator decision: scoping note added in code + plan.md; consistent threading + integration test deferred to a later phase)
-- [ ] (suggestion) Boundary `width == min_allowable_swath` (strict `<` keeps it as valid) is untested — add a boundary test — `src/RecordSwath.cpp:217`
+- [x] (suggestion) Boundary `width == min_allowable_swath` (strict `<` keeps it as valid) is untested — add a boundary test — `src/RecordSwath.cpp:217`
 - [ ] (suggestion) Redundant trailing blank line at end of `configure()` (only new lint finding on a touched line) — `src/SurveyPath.cpp:131`
 
 ### Notes

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -172,7 +172,7 @@ Ready for review-code. No push/PR performed (host publishes after local review).
 ### Findings
 - [x] (suggestion) `min_allowable_swath` threshold applied in `SwathWidth()` but not `SwathOuterPts`/`OuterPoint`/`AllSwathWidths` — partial below-threshold coverage keeps `all_zero` false and zero-offsets sub-threshold points; document or apply consistently + add PathPlan integration test (cross-pass confirmed: Lens A + Lens B) — `src/RecordSwath.cpp:217` / `src/PathPlan.cpp:85` (documented per operator decision: scoping note added in code + plan.md; consistent threading + integration test deferred to a later phase)
 - [x] (suggestion) Boundary `width == min_allowable_swath` (strict `<` keeps it as valid) is untested — add a boundary test — `src/RecordSwath.cpp:217`
-- [ ] (suggestion) Redundant trailing blank line at end of `configure()` (only new lint finding on a touched line) — `src/SurveyPath.cpp:131`
+- [x] (suggestion) Redundant trailing blank line at end of `configure()` (only new lint finding on a touched line) — `src/SurveyPath.cpp:131`
 
 ### Notes
 - Plan adherence strong: all planned files changed, no scope creep; finite `numeric_limits<double>::max()` range sentinels, dead `m_swath_interval` retired, `find_package(ament_cmake_ros)` added, `package.xml` correctly unchanged.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -170,7 +170,7 @@ Ready for review-code. No push/PR performed (host publishes after local review).
 **Round**: 1 | **Ship**: recommended — no must-fix; clean, plan-faithful Phase-1 increment, default behaviour unchanged
 
 ### Findings
-- [ ] (suggestion) `min_allowable_swath` threshold applied in `SwathWidth()` but not `SwathOuterPts`/`OuterPoint`/`AllSwathWidths` — partial below-threshold coverage keeps `all_zero` false and zero-offsets sub-threshold points; document or apply consistently + add PathPlan integration test (cross-pass confirmed: Lens A + Lens B) — `src/RecordSwath.cpp:217` / `src/PathPlan.cpp:85`
+- [x] (suggestion) `min_allowable_swath` threshold applied in `SwathWidth()` but not `SwathOuterPts`/`OuterPoint`/`AllSwathWidths` — partial below-threshold coverage keeps `all_zero` false and zero-offsets sub-threshold points; document or apply consistently + add PathPlan integration test (cross-pass confirmed: Lens A + Lens B) — `src/RecordSwath.cpp:217` / `src/PathPlan.cpp:85` (documented per operator decision: scoping note added in code + plan.md; consistent threading + integration test deferred to a later phase)
 - [ ] (suggestion) Boundary `width == min_allowable_swath` (strict `<` keeps it as valid) is untested — add a boundary test — `src/RecordSwath.cpp:217`
 - [ ] (suggestion) Redundant trailing blank line at end of `configure()` (only new lint finding on a touched line) — `src/SurveyPath.cpp:131`
 

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -194,3 +194,25 @@ Address all three suggestions before publishing, per these per-finding decisions
 - **(3) Apply.** Remove the redundant trailing blank line at end of `configure()`
   (`src/SurveyPath.cpp:131`).
 Re-run the package build + tests; then the host re-dispatches review-code.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-30 16:20 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-4 at `ec58534`
+**Addressed**: `## Local Review (Pre-Push)` (2026-06-30 16:10 +00:00, branch `feature/issue-4` at `df6b2a9`), per the operator publish-checkpoint decision recorded in that entry.
+**Commits**: `92f8e13`, `b662111`, `ec58534`
+
+### Actions
+- [x] (suggestion 1) `min_allowable_swath` threshold scoped to `SwathWidth()` only — **documented, not applied** per operator decision — `src/RecordSwath.cpp:217` (Phase-1 scoping note added at the threshold in `src/RecordSwath.cpp` and in `.agent/work-plans/issue-4/plan.md`; threading the threshold through `SwathOuterPts`/`OuterPoint`/`AllSwathWidths` + a PathPlan integration test is deferred to a later phase — default threshold `0.0` ⇒ no behavior change today) — commit `92f8e13`
+- [x] (suggestion 2) Boundary `width == min_allowable_swath` now tested — added `RecordSwathThreshold.AtThresholdReturnsRealWidth` (strict `<` ⇒ value at exactly the threshold returns the real width) — `test/test_parameters.cpp` — commit `b662111`
+- [x] (suggestion 3) Removed redundant trailing blank line at end of `configure()` — `src/SurveyPath.cpp` — commit `ec58534`
+
+### Build & test
+- `./core_ws/build.sh manda_coverage` — clean (only pre-existing `-Wunused-parameter`/`-Wsign-compare` warnings in legacy sources; none from this change).
+- gtest `test_parameters`: **7/7 pass** (3 parameter + 4 thresholding, up from 6 with the new boundary case).
+- Lint on touched files re-verified directly: `test/test_parameters.cpp` clean (uncrustify, cpplint, copyright); the targeted `configure()` blank-line cpplint finding is resolved. Legacy MOOS-derived lint baseline is pre-existing and unchanged.
+
+### Next step
+Ready for review-code re-review of the fixes. No push/PR performed (host publishes after local review).

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -80,3 +80,21 @@ work is self-contained; it does not depend on any other open issue.
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-30 15:23 +00:00
+**By**: Claude Code Agent (Claude Opus)
+<!-- Name matches the Plan Authored entry, but this is a fresh-context Opus sub-agent reviewing a Sonnet-authored plan — genuinely independent, not an in-context self-review, so no self-review annotation. -->
+
+**Plan**: `.agent/work-plans/issue-4/plan.md` at `4ae669d`
+**PR**: PR-less (--issue mode; gh unauthenticated — issue context read from the Issue Review entry above)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Range descriptors for unbounded-above params are encoded wrong: `swath_record_interval` `from_value=0.001` with default `to_value=0.0` rejects the default 10.0 at declare time (configure() throws); `min_allowable_swath` `to_value=0.0` yields range `[0,0]` so the threshold can never be raised. Use finite upper sentinels (e.g. `numeric_limits<double>::max()`) per the Issue Review's "large sentinel" recommendation — there is no existing `ParameterDescriptor` pattern in the repo to copy. — `plan.md:43-44`
+- [ ] (suggestion) "Test what breaks": tests cover only ROS-level declaration/range rejection; the new `SwathWidth()` thresholding logic (feeds PathPlan `all_zero` at `PathPlan.cpp:97-103` and zeroes the offset at `PathPlan.cpp:86`) is untested. Add a `RecordSwath::SwathWidth()` unit test or document the gap. — `plan.md:55-62`
+- [ ] (suggestion) BUILD_TESTING block needs `find_package(ament_cmake_ros REQUIRED)` to expose `ament_add_ros_isolated_gtest`; current block only runs lint. `ament_cmake_ros` is already a buildtool_depend, so step 7's test_depend add is a no-op. — `plan.md:63-68`
+
+### Notes
+- Structurally sound: file targeting, dead-member (`m_swath_interval`) and never-read (`m_min_allowable_swath`) claims, and the "PathPlan ctor signature unchanged → no external-caller breakage" consequence all verified against source. The must-fix is a concrete correctness defect in the parameter-range encoding, not a structural re-plan.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -1,0 +1,70 @@
+---
+issue: 4
+---
+
+# Issue #4 — Expose coverage-density tuning constants as declared parameters
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-30 15:10 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #4
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+**Well-scoped?** Yes — Phase 1 is explicitly bounded to launch-time configurability only;
+live/runtime settability is deferred to Phase 2 (`rolker/unh_echoboats_project11#358`).
+All changes are within a single package (`manda_coverage`) and can land in a single PR.
+
+**Right repo?** Yes — `SurveyPath`, `PathPlan`, and `RecordSwath` all live in the
+`manda_coverage` project repo. No workspace-infra changes required.
+
+**Dependencies?** Parent tracker is `rolker/unh_echoboats_project11#358`, but this Phase 1
+work is self-contained; it does not depend on any other open issue.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Promotes hardcoded knobs to operator-visible ROS 2 parameters with bounds descriptors — direct improvement to configurability |
+| A change includes its consequences | OK | Issue explicitly includes tests (defaults + out-of-range rejection) and retires the dead `m_swath_interval` member |
+| Only what's needed | OK | Phase 1 scope is minimal and correct — no runtime settability, no extra abstraction |
+| Improve incrementally | OK | Single package, single PR, explicit Phase 1 of a two-phase plan |
+| Test what breaks | OK | Tests target the declaration behavior (defaults and range rejection), which is the risky logic here |
+| Workspace vs. project separation | OK | All changes are in `manda_coverage`; workspace infra untouched |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| ADR-0002 — Worktree isolation | Yes | Already satisfied — `issue-manda_coverage-4` worktree exists on `feature/issue-4` |
+| ADR-0008 — Follow ROS 2 conventions | Yes | `ParameterDescriptor` with `floating_point_range` is the correct ROS 2 pattern; `configure()` is the right declaration site; implementation should follow ROS 2 Rolling conventions |
+| ADR-0013 — progress.md vocabulary | Yes | This entry (Issue Review) |
+
+### Consequences
+
+- `PathPlan` constructor signature changes (margin, max_bend_angle become parameters
+  read in `configure()` and passed through) — verify no other callers outside the
+  package break.
+- `RecordSwath` construction interval becomes a parameter — verify `SurveyPath.cpp:32`
+  (`m_swath_record(10)`) is updated to use the declared value.
+- The dead `m_swath_interval` member (`SurveyPath.h:71`) must be removed — no other
+  update needed since it is never read.
+
+### Recommendations
+
+- Verify that `floating_point_range` enforcement is active for your ROS 2 distro:
+  in Rolling/Humble, the node rejects out-of-range values at `declare_parameter` and
+  `set_parameter` time, so `ParameterDescriptor` enforcement is real, not just advisory.
+  The test for out-of-range rejection should confirm this behavior rather than testing
+  only the descriptor metadata.
+- The `min_allowable_swath` range (`>= 0`) omits an upper bound — this is fine; omit
+  the max or set it to a large sentinel rather than leaving it implicitly unconstrained
+  in the descriptor.
+
+### Actions
+- [ ] Verify no external callers of `PathPlan(...)` constructor are broken by the signature change.
+- [ ] Confirm out-of-range rejection test exercises ROS 2 node-level validation (not just descriptor field inspection).

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -178,3 +178,19 @@ Ready for review-code. No push/PR performed (host publishes after local review).
 - Plan adherence strong: all planned files changed, no scope creep; finite `numeric_limits<double>::max()` range sentinels, dead `m_swath_interval` retired, `find_package(ament_cmake_ros)` added, `package.xml` correctly unchanged.
 - Range enforcement verified active at node `set_parameter` level (not just descriptor metadata). Build/CMake/test wiring clean; new `test/test_parameters.cpp` is lint-clean. Legacy MOOS lint baseline is pre-existing and not attributed to this PR.
 - Tests reported 6/6 passing in the Implementation entry; not independently re-run this session.
+
+### Operator decision (publish checkpoint, 2026-06-30)
+Address all three suggestions before publishing, per these per-finding decisions:
+- **(1) Document, do NOT apply.** Keep `min_allowable_swath` thresholding scoped to
+  `SwathWidth()` only (it drives PathPlan's `all_zero` coverage-complete check).
+  Do **not** thread it through `SwathOuterPts`/`OuterPoint`/`AllSwathWidths`. Add a
+  short Phase-1 scoping note in the code (comment near the `SwathWidth()` threshold
+  and/or the param declaration) explaining that consistent below-threshold handling
+  across the sibling accessors is deferred (default threshold `0.0` ⇒ no behavior
+  change today; full coverage-complete semantics with a non-zero threshold is a
+  later phase). Reflect the same note in `plan.md` if it touches that behavior.
+- **(2) Apply.** Add the `width == min_allowable_swath` boundary test (strict `<`
+  ⇒ value at exactly the threshold stays valid / returns the real width).
+- **(3) Apply.** Remove the redundant trailing blank line at end of `configure()`
+  (`src/SurveyPath.cpp:131`).
+Re-run the package build + tests; then the host re-dispatches review-code.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -68,3 +68,15 @@ work is self-contained; it does not depend on any other open issue.
 ### Actions
 - [ ] Verify no external callers of `PathPlan(...)` constructor are broken by the signature change.
 - [ ] Confirm out-of-range rejection test exercises ROS 2 node-level validation (not just descriptor field inspection).
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-30 17:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-4/plan.md` at `4ae669d`
+**Branch**: feature/issue-4 at `4ae669d`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -216,3 +216,27 @@ Re-run the package build + tests; then the host re-dispatches review-code.
 
 ### Next step
 Ready for review-code re-review of the fixes. No push/PR performed (host publishes after local review).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-30 16:31 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-4 at `1eef7b7`
+**Mode**: pre-push
+**Depth**: Standard (reason: multi-file C++ touching ROS 2 parameter API + new test target; single package)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 2 | **Ship**: recommended — no must-fix; all three round-1 suggestions addressed and verified, tests 7/7, clean re-review
+
+### Findings
+- [ ] No issues found. LGTM.
+
+### Notes
+- Re-review of the three commits addressing the round-1 (2026-06-30 16:10) suggestions: `92f8e13` (Phase-1 scoping note in `src/RecordSwath.cpp` + plan.md), `b662111` (`RecordSwathThreshold.AtThresholdReturnsRealWidth` boundary test), `ec58534` (trailing blank line removed from `configure()`). All applied as the operator decided.
+- Standard tier: two disjoint-lens Claude Adversarial passes. Lens A: no findings. Lens B raised one must-fix (`rclcpp::init()` in `SetUp()` failing on 2nd+ `TEST_F`) — **adjudicated false positive**: paired `init`/`shutdown` per fixture is the supported pattern, confirmed by `test_parameters.gtest.xml` (`SurveyPathParameterTest` 3 fixtures, 0 failures; 7/7 overall). Lens B's remaining items are pre-existing structural patterns (configure re-entry, subscription-before-config, descriptor re-validation) not introduced by this PR and with no Phase-1 impact (threshold default 0.0 == param default 0.0).
+- Static analysis (cpplint/ament) clean on all touched lines; the cpplint hits are pre-existing legacy MOOS-derived lines, not attributable to this PR. New `test/test_parameters.cpp` lint-clean.
+- Plan adherence strong; documented `SwathWidth()`-only threshold scoping matches code (`PathPlan.cpp:85,97` confirm `SwathWidth` is the sole feeder of the `all_zero` check). Governance, ADR-0008/0013/0002, and consequences map all Pass/Done.
+
+### Next step
+Approved pre-push review → host pushes / opens PR, then dispatches **triage-reviews** in a fresh-context sub-agent. No push/PR performed by this skill.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -98,3 +98,61 @@ work is self-contained; it does not depend on any other open issue.
 
 ### Notes
 - Structurally sound: file targeting, dead-member (`m_swath_interval`) and never-read (`m_min_allowable_swath`) claims, and the "PathPlan ctor signature unchanged → no external-caller breakage" consequence all verified against source. The must-fix is a concrete correctness defect in the parameter-range encoding, not a structural re-plan.
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-30 16:05 +00:00
+**By**: Claude Opus
+
+**Branch**: feature/issue-4 at `b9ec729`
+**Commits**:
+- `c231faf` — RecordSwath setters (`SetInterval`, `SetMinAllowableSwath`) + `SwathWidth()` thresholding
+- `444f9ba` — SurveyPath parameter declarations + dead-member removal
+- `9f6886a` — tests + CMake `BUILD_TESTING` wiring
+- `b9ec729` — plan sync
+
+### What was implemented
+Implemented the plan as written with all three Plan Review corrections applied:
+
+1. **Range-descriptor encoding (MUST-FIX, applied).** Parameters declared in
+   `SurveyPath::configure()` via a local `declare_bounded` lambda using
+   `FloatingPointRange` descriptors:
+   - `swath_overlap` `[0.0, 1.0]` default `0.2`
+   - `max_bend_angle` `[0.0, 90.0]` default `60.0`
+   - `swath_record_interval` `[0.001, std::numeric_limits<double>::max()]` default `10.0`
+   - `min_allowable_swath` `[0.0, std::numeric_limits<double>::max()]` default `0.0`
+   Finite `max()` sentinels used for unbounded-above ranges (no `to_value=0.0`);
+   `#include <limits>` added.
+
+2. **SwathWidth() thresholding test (SUGGESTION, applied).** `RecordSwathThreshold`
+   suite covers below-threshold → `0.0`, at/above → real width, and default `0.0`
+   threshold never zeroing a positive width. (A test-helper bug — first `AddRecord`
+   at `(0,0,heading=0)` collided with the zero-initialised `m_previous_record`
+   duplicate guard and was silently dropped — was found and fixed by using
+   heading `45.0`.)
+
+3. **CMake test dependency (SUGGESTION, applied).** Added
+   `find_package(ament_cmake_ros REQUIRED)` to the `BUILD_TESTING` block to expose
+   `ament_add_ros_isolated_gtest`. Plan step 7's `package.xml` `<test_depend>` add
+   was correctly skipped as a **no-op** — `ament_cmake_ros` is already a
+   `buildtool_depend`.
+
+Dead `m_swath_interval` member removed from `SurveyPath.h`; redundant
+`m_swath_record(10)` constructor initialiser dropped (defaults to `10`,
+overridden by `configure()`).
+
+### Build & test
+- `./core_ws/build.sh manda_coverage` — clean (built via `--packages-up-to` to
+  pick up in-workspace deps `marine_nav_interfaces`/`marine_nav_utilities` on
+  first build; only pre-existing `-Wunused-parameter` warnings in
+  `action_server.cpp`, none from this change).
+- gtest `test_parameters`: **6/6 pass** (3 parameter + 3 thresholding).
+- The package's `ament_lint` suite has a large pre-existing baseline of
+  uncrustify/cpplint/copyright failures across the legacy MOOS-derived sources
+  (header-guard style, comment spacing, missing copyright, etc.) — out of scope
+  for this issue. The new `test/test_parameters.cpp` is lint-clean (uncrustify,
+  cpplint, copyright all pass) and the one >100-char line introduced in
+  `SurveyPath.cpp` was wrapped so no new cpplint line-length failure is added.
+
+### Next step
+Ready for review-code. No push/PR performed (host publishes after local review).

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -156,3 +156,25 @@ overridden by `configure()`).
 
 ### Next step
 Ready for review-code. No push/PR performed (host publishes after local review).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-30 16:10 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-4 at `df6b2a9`
+**Mode**: pre-push
+**Depth**: Standard (reason: multi-file C++ source touching ROS 2 parameter API + new test target; single package)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; clean, plan-faithful Phase-1 increment, default behaviour unchanged
+
+### Findings
+- [ ] (suggestion) `min_allowable_swath` threshold applied in `SwathWidth()` but not `SwathOuterPts`/`OuterPoint`/`AllSwathWidths` — partial below-threshold coverage keeps `all_zero` false and zero-offsets sub-threshold points; document or apply consistently + add PathPlan integration test (cross-pass confirmed: Lens A + Lens B) — `src/RecordSwath.cpp:217` / `src/PathPlan.cpp:85`
+- [ ] (suggestion) Boundary `width == min_allowable_swath` (strict `<` keeps it as valid) is untested — add a boundary test — `src/RecordSwath.cpp:217`
+- [ ] (suggestion) Redundant trailing blank line at end of `configure()` (only new lint finding on a touched line) — `src/SurveyPath.cpp:131`
+
+### Notes
+- Plan adherence strong: all planned files changed, no scope creep; finite `numeric_limits<double>::max()` range sentinels, dead `m_swath_interval` retired, `find_package(ament_cmake_ros)` added, `package.xml` correctly unchanged.
+- Range enforcement verified active at node `set_parameter` level (not just descriptor metadata). Build/CMake/test wiring clean; new `test/test_parameters.cpp` is lint-clean. Legacy MOOS lint baseline is pre-existing and not attributed to this PR.
+- Tests reported 6/6 passing in the Implementation entry; not independently re-run this session.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,16 @@ install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  # ament_cmake_ros provides ament_add_ros_isolated_gtest. It is already a
+  # buildtool_depend, so no package.xml test_depend is required.
+  find_package(ament_cmake_ros REQUIRED)
+
+  ament_add_ros_isolated_gtest(test_parameters test/test_parameters.cpp)
+  target_link_libraries(test_parameters
+    ${PROJECT_NAME}
+    rclcpp::rclcpp
+  )
 endif()
 
 ament_package()

--- a/include/manda_coverage/RecordSwath.h
+++ b/include/manda_coverage/RecordSwath.h
@@ -131,6 +131,20 @@ public:
   double IntervalDist() { return m_interval; }
 
   /**
+   * Sets the distance between subsequent analysis intervals for swath minimums.
+   * @param interval Interval distance in meters
+   */
+  void SetInterval(double interval) { m_interval = interval; }
+
+  /**
+   * Sets the minimum swath width considered valid coverage. Widths below this
+   * threshold are reported as zero by SwathWidth(), which drives the
+   * coverage-complete (all_zero) check in PathPlan.
+   * @param min_swath Minimum allowable swath width in meters
+   */
+  void SetMinAllowableSwath(double min_swath) { m_min_allowable_swath = min_swath; }
+
+  /**
    * Determines if the record has valid points for building a path.
    */
   bool ValidRecord();

--- a/include/manda_coverage/SurveyPath.h
+++ b/include/manda_coverage/SurveyPath.h
@@ -68,7 +68,6 @@ private:
   
 // Configuration variables
   BoatSide m_first_swath_side = BoatSide::Stbd;
-  double m_swath_interval = 10;
   bool m_remove_in_coverage = false;
   double m_swath_overlap = 0.2;
   double m_max_bend_angle = 60;

--- a/src/RecordSwath.cpp
+++ b/src/RecordSwath.cpp
@@ -214,6 +214,15 @@ double RecordSwath::SwathWidth(BoatSide side, unsigned int index)
         }
         // Widths below the minimum allowable swath are reported as no coverage,
         // which lets PathPlan's all_zero check signal survey completion.
+        //
+        // Phase 1 scope: the threshold is applied here in SwathWidth() only,
+        // not in the sibling accessors SwathOuterPts()/OuterPoint()/
+        // AllSwathWidths(). That is intentional — SwathWidth() is what feeds
+        // PathPlan's all_zero coverage-complete check, and the default
+        // threshold of 0.0 means no behavior change today. Threading the
+        // threshold consistently through the sibling accessors (so that
+        // sub-threshold points are handled identically everywhere when the
+        // threshold is non-zero) is deferred to a later phase.
         if (width < m_min_allowable_swath)
         {
             return 0;

--- a/src/RecordSwath.cpp
+++ b/src/RecordSwath.cpp
@@ -203,14 +203,22 @@ double RecordSwath::SwathWidth(BoatSide side, unsigned int index)
     if (m_min_record.size() > index)
     {
         std::list<SwathRecord>::iterator list_record = std::next(m_min_record.begin(), index);
+        double width = 0;
         if (side == BoatSide::Stbd)
         {
-            return list_record->swath_stbd;
+            width = list_record->swath_stbd;
         }
         else if (side == BoatSide::Port)
         {
-            return list_record->swath_port;
+            width = list_record->swath_port;
         }
+        // Widths below the minimum allowable swath are reported as no coverage,
+        // which lets PathPlan's all_zero check signal survey completion.
+        if (width < m_min_allowable_swath)
+        {
+            return 0;
+        }
+        return width;
     }
     return 0;
 }

--- a/src/SurveyPath.cpp
+++ b/src/SurveyPath.cpp
@@ -6,7 +6,10 @@
 /************************************************************/
 
 #include <iterator>
+#include <limits>
 //#include <regex>
+#include "rcl_interfaces/msg/floating_point_range.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "manda_coverage/lib_geometry/AngleUtils.h"
 #include "manda_coverage/lib_geometry/XYFormatUtilsSegl.h"
 #include "manda_coverage/RecordSwath.h"
@@ -29,8 +32,7 @@ namespace manda_coverage
 // Constructor
 
 SurveyPath::SurveyPath(NodeInterfaces node_interfaces)
- :m_swath_record(10),
-  node_interfaces_(node_interfaces),
+ :node_interfaces_(node_interfaces),
   logger_(node_interfaces.get_node_logging_interface()->get_logger()),
   clock_(node_interfaces.get_node_clock_interface()->get_clock())
 {
@@ -93,6 +95,39 @@ void SurveyPath::configure()
   if(!parameter_interface->has_parameter("lead_out_distance"))
     parameter_interface->declare_parameter("lead_out_distance", rclcpp::ParameterValue(lead_out_distance_));
   lead_out_distance_ = parameter_interface->get_parameter("lead_out_distance").as_double();
+
+  // Coverage-density tuning parameters. Declared with floating-point-range
+  // descriptors so the node rejects out-of-range values at declare/set time.
+  auto declare_bounded = [&](const std::string & name, double default_value,
+                             double from_value, double to_value,
+                             const std::string & description) -> double
+  {
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.description = description;
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.from_value = from_value;
+    range.to_value = to_value;
+    range.step = 0.0;
+    descriptor.floating_point_range.push_back(range);
+    if(!parameter_interface->has_parameter(name))
+      parameter_interface->declare_parameter(
+        name, rclcpp::ParameterValue(default_value), descriptor);
+    return parameter_interface->get_parameter(name).as_double();
+  };
+
+  m_swath_overlap = declare_bounded("swath_overlap", 0.2, 0.0, 1.0,
+    "Fraction of swath width to overlap adjacent survey lines [0-1]");
+  m_max_bend_angle = declare_bounded("max_bend_angle", 60.0, 0.0, 90.0,
+    "Maximum bend angle between path segments, in degrees");
+  double swath_record_interval = declare_bounded("swath_record_interval", 10.0,
+    0.001, std::numeric_limits<double>::max(),
+    "Distance between swath-minimum analysis intervals, in meters");
+  double min_allowable_swath = declare_bounded("min_allowable_swath", 0.0,
+    0.0, std::numeric_limits<double>::max(),
+    "Minimum swath width treated as valid coverage, in meters");
+
+  m_swath_record.SetInterval(swath_record_interval);
+  m_swath_record.SetMinAllowableSwath(min_allowable_swath);
 
 }
 

--- a/src/SurveyPath.cpp
+++ b/src/SurveyPath.cpp
@@ -128,7 +128,6 @@ void SurveyPath::configure()
 
   m_swath_record.SetInterval(swath_record_interval);
   m_swath_record.SetMinAllowableSwath(min_allowable_swath);
-
 }
 
 void SurveyPath::activate()

--- a/test/test_parameters.cpp
+++ b/test/test_parameters.cpp
@@ -147,3 +147,12 @@ TEST(RecordSwathThreshold, DefaultThresholdReturnsRealWidth)
   RecordSwath record = makeRecordWithSwath(10.0);
   EXPECT_DOUBLE_EQ(record.SwathWidth(BoatSide::Stbd, 0), 10.0);
 }
+
+TEST(RecordSwathThreshold, AtThresholdReturnsRealWidth)
+{
+  // Boundary: the threshold is a strict `<`, so a width exactly equal to
+  // min_allowable_swath is still valid coverage and returns the real width.
+  RecordSwath record = makeRecordWithSwath(10.0);
+  record.SetMinAllowableSwath(10.0);
+  EXPECT_DOUBLE_EQ(record.SwathWidth(BoatSide::Stbd, 0), 10.0);
+}

--- a/test/test_parameters.cpp
+++ b/test/test_parameters.cpp
@@ -1,0 +1,149 @@
+// Copyright 2026 Roland Arsenault
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Tests for the coverage-density tuning parameters declared by SurveyPath, and
+// the RecordSwath swath thresholding that backs the min_allowable_swath knob.
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "manda_coverage/RecordSwath.h"
+#include "manda_coverage/SurveyPath.h"
+
+using manda_coverage::BoatSide;
+using manda_coverage::NodeInterfaces;
+using manda_coverage::RecordSwath;
+using manda_coverage::SurveyPath;
+
+// ---------------------------------------------------------------------------
+// SurveyPath parameter declaration tests
+// ---------------------------------------------------------------------------
+
+class SurveyPathParameterTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_survey_path");
+    survey_path_ = std::make_unique<SurveyPath>(NodeInterfaces(*node_));
+    survey_path_->configure();
+  }
+
+  void TearDown() override
+  {
+    survey_path_.reset();
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::unique_ptr<SurveyPath> survey_path_;
+};
+
+TEST_F(SurveyPathParameterTest, DefaultParameters)
+{
+  EXPECT_DOUBLE_EQ(node_->get_parameter("swath_overlap").as_double(), 0.2);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("max_bend_angle").as_double(), 60.0);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("swath_record_interval").as_double(), 10.0);
+  EXPECT_DOUBLE_EQ(node_->get_parameter("min_allowable_swath").as_double(), 0.0);
+}
+
+TEST_F(SurveyPathParameterTest, OutOfRangeRejection)
+{
+  auto reject = [&](const std::string & name, double value)
+    {
+      auto result = node_->set_parameter(rclcpp::Parameter(name, value));
+      EXPECT_FALSE(result.successful)
+        << name << " unexpectedly accepted out-of-range value " << value;
+    };
+
+  // swath_overlap: [0.0, 1.0]
+  reject("swath_overlap", -0.1);
+  reject("swath_overlap", 1.1);
+  // max_bend_angle: [0.0, 90.0]
+  reject("max_bend_angle", -1.0);
+  reject("max_bend_angle", 90.5);
+  // swath_record_interval: (0.0, max] -- 0.0 is below from_value 0.001
+  reject("swath_record_interval", 0.0);
+  // min_allowable_swath: [0.0, max]
+  reject("min_allowable_swath", -1.0);
+}
+
+TEST_F(SurveyPathParameterTest, InRangeAccepted)
+{
+  auto accept = [&](const std::string & name, double value)
+    {
+      auto result = node_->set_parameter(rclcpp::Parameter(name, value));
+      EXPECT_TRUE(result.successful)
+        << name << " unexpectedly rejected in-range value " << value;
+    };
+
+  accept("swath_overlap", 0.5);
+  accept("max_bend_angle", 45.0);
+  accept("swath_record_interval", 25.0);
+  accept("min_allowable_swath", 3.0);
+}
+
+// ---------------------------------------------------------------------------
+// RecordSwath::SwathWidth() thresholding tests
+// ---------------------------------------------------------------------------
+
+// Builds a RecordSwath holding a single recorded swath of the given width.
+// Two records separated by more than the interval force MinInterval() to
+// populate m_min_record so SwathWidth(side, 0) returns a real entry.
+static RecordSwath makeRecordWithSwath(double width)
+{
+  RecordSwath record(1.0);
+  record.SetOutputSide(BoatSide::Stbd);
+  // Heading 45 keeps the first record distinct from the zero-initialised
+  // previous record so the duplicate-location guard does not drop it. The
+  // 10 m separation exceeds the 1 m interval, forcing MinInterval() to store
+  // the swath in m_min_record where SwathWidth(side, 0) can read it.
+  record.AddRecord(width, width, 0.0, 0.0, 45.0, 10.0);
+  record.AddRecord(width, width, 10.0, 0.0, 45.0, 10.0);
+  return record;
+}
+
+TEST(RecordSwathThreshold, AboveThresholdReturnsRealWidth)
+{
+  RecordSwath record = makeRecordWithSwath(10.0);
+  record.SetMinAllowableSwath(5.0);
+  EXPECT_DOUBLE_EQ(record.SwathWidth(BoatSide::Stbd, 0), 10.0);
+}
+
+TEST(RecordSwathThreshold, BelowThresholdReturnsZero)
+{
+  RecordSwath record = makeRecordWithSwath(10.0);
+  record.SetMinAllowableSwath(15.0);
+  EXPECT_DOUBLE_EQ(record.SwathWidth(BoatSide::Stbd, 0), 0.0);
+}
+
+TEST(RecordSwathThreshold, DefaultThresholdReturnsRealWidth)
+{
+  // Default min_allowable_swath of 0.0 must not zero out any positive width.
+  RecordSwath record = makeRecordWithSwath(10.0);
+  EXPECT_DOUBLE_EQ(record.SwathWidth(BoatSide::Stbd, 0), 10.0);
+}


### PR DESCRIPTION
## Summary

Phase 1 of exposing the manda coverage planner's tuning knobs to the operator
(parent tracker: `rolker/unh_echoboats_project11`#358). Promotes four hardcoded
coverage-density constants to ROS 2 declared parameters with `ParameterDescriptor`
bounds, so they are configurable at launch time. Live/runtime settability is
**out of scope here** — deferred to Phase 2 (manda_coverage#5).

## Parameters added (declared in `SurveyPath::configure()`)

| ROS name | default | range | was |
|---|---|---|---|
| `swath_overlap` | `0.2` | `[0.0, 1.0]` | `m_swath_overlap` hardcode (`SurveyPath.h`) |
| `max_bend_angle` | `60.0` | `[0.0, 90.0]` | `m_max_bend_angle` hardcode (`SurveyPath.h`) |
| `swath_record_interval` | `10.0` | `[0.001, DBL_MAX]` | `m_swath_record(10)` ctor literal |
| `min_allowable_swath` | `0.0` | `[0.0, DBL_MAX]` | `m_min_allowable_swath` (was init-but-never-read) |

Unbounded-above ranges use finite `std::numeric_limits<double>::max()` sentinels
(not `to_value=0.0`, which would reject the default at declare time).

## Other changes

- `RecordSwath`: added `SetInterval()` / `SetMinAllowableSwath()` setters and wired
  `min_allowable_swath` into `SwathWidth()` (returns `0.0` below threshold, driving
  PathPlan's `all_zero` coverage-complete check). A Phase-1 scoping comment documents
  that consistent below-threshold handling across the sibling accessors
  (`SwathOuterPts`/`OuterPoint`/`AllSwathWidths`) is intentionally deferred — default
  threshold `0.0` ⇒ no behavior change today.
- Removed dead `m_swath_interval` member (`SurveyPath.h`) and the redundant
  `m_swath_record(10)` constructor initialiser.
- New `test/test_parameters.cpp` (`ament_add_ros_isolated_gtest`): parameter defaults,
  node-level out-of-range rejection, and `SwathWidth()` thresholding incl. the
  `width == min_allowable_swath` boundary. **7/7 pass.** Added
  `find_package(ament_cmake_ros REQUIRED)` to the `BUILD_TESTING` block.

## Testing

- `colcon build` clean (only pre-existing warnings in legacy sources).
- `test_parameters`: 7/7 pass.
- The legacy MOOS-derived lint baseline is pre-existing and untouched; the new test
  file is lint-clean.

## Process

Default behavior is unchanged (every default equals the prior hardcoded constant).
Developed via the run-issue lifecycle (review-issue → plan → review-plan → implement
→ review-code ×2 + address-findings); both pre-push reviews approved, 0 must-fix.

Closes #4

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
